### PR TITLE
Hashids is not cryptographically secure, so look for a specified salt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Flask-Hashids is configured through the standard Flask config API. These are the
 
 - **HASHIDS_ALPHABET**: Read more about that in [Hashids documentation](https://github.com/davidaurelio/hashids-python#using-a-custom-alphabet)
 - **HASHIDS_MIN_LENGTH**: Read more about that in [Hashids documentation](https://github.com/davidaurelio/hashids-python#controlling-hash-length)
-- **SECRET_KEY**: Used as the salt, read more in [Hashids documentation](https://github.com/davidaurelio/hashids-python#using-a-custom-salt)
+- **HASHIDS_SALT**: It is strongly recommended that this is NEVER the same as the `SECRET_KEY`. Read more about this option in [Hashids documentation](https://github.com/davidaurelio/hashids-python#using-a-custom-salt)
 
 ## Examples
 

--- a/examples/basic_crud/app.py
+++ b/examples/basic_crud/app.py
@@ -5,7 +5,8 @@ from werkzeug.exceptions import HTTPException
 
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'secret!'
+app.config['SECRET_KEY'] = 'top_secret_key'
+app.config['HASHIDS_SALT'] = 'secret!'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
 db = SQLAlchemy(app)
 hashids = Hashids(app)

--- a/examples/minimal/app.py
+++ b/examples/minimal/app.py
@@ -4,7 +4,8 @@ from flask_sqlalchemy import SQLAlchemy
 
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'secret!'
+app.config['SECRET_KEY'] = 'top_secret_key'
+app.config['HASHIDS_SALT'] = 'secret!'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
 db = SQLAlchemy(app)
 hashids = Hashids(app)

--- a/flask_hashids.py
+++ b/flask_hashids.py
@@ -2,6 +2,7 @@ from flask import abort, current_app, Flask
 from hashids import Hashids as _Hashids
 from typing import Any, Dict
 from werkzeug.routing import BaseConverter
+from hashlib import sha256
 
 
 class HashidMixin:
@@ -67,8 +68,8 @@ class Hashids:
         if 'HASHIDS_MIN_LENGTH' in app.config:
             hashids_config['min_length'] = \
                 int(app.config['HASHIDS_MIN_LENGTH'])
-        if 'SECRET_KEY' in app.config:
-            hashids_config['salt'] = app.config['SECRET_KEY']
+        if 'HASHIDS_SALT' in app.config:
+            hashids_config['salt'] = app.config['HASHIDS_SALT']
         self._hashids = _Hashids(**hashids_config)
         if not hasattr(app, 'extensions'):
             app.extensions = {}


### PR DESCRIPTION
Resolves #5 by using a separate configuration variable rather than the secret key for the Hashids salt